### PR TITLE
Numeric keyboard for times

### DIFF
--- a/app/ui/src/constants/constants.jsx
+++ b/app/ui/src/constants/constants.jsx
@@ -94,6 +94,7 @@ export const FLIGHT_TIME_SLOT_PROPS = {
       // Allow clearing or partial input
       e.target.value = value;
     },
+    inputMode: 'numeric'
   },
 };
 


### PR DESCRIPTION
Added `inputMode: 'numeric'` to the `FLIGHT_TIME_SLOT_PROPS` in order for mobile devices to show a numeric keyboard when editing a time field.